### PR TITLE
fix: restore broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,4 +55,4 @@ VoiceTransl是一站式离线AI视频字幕生成和翻译软件，支持Mac和W
 
 ## 如果对你有帮助的话请给一个Star!
 
-![Star History Chart](https://api.star-history.com/svg?repos=shinnpuru/VoiceTransl&type=Date)
+![Star History Chart](https://star-history.dera.page/svg?repos=shinnpuru/VoiceTransl&type=Date)


### PR DESCRIPTION
The star history chart in the README is currently broken because the GitHub stargazer API has become restricted. This PR updates the chart URL to a working replacement so the chart displays again. Please merge it to fix the README.